### PR TITLE
Fix map scene case

### DIFF
--- a/src/game/Game.tscn
+++ b/src/game/Game.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://src/game/Game.cs" id="1_17mmo"]
 [ext_resource type="PackedScene" uid="uid://pjmfnaiwwwed" path="res://src/player_camera/PlayerCamera.tscn" id="2_g21k4"]
-[ext_resource type="PackedScene" uid="uid://daho0q3ic4vmn" path="res://src/map/map.tscn" id="3_cpkwg"]
+[ext_resource type="PackedScene" uid="uid://daho0q3ic4vmn" path="res://src/map/Map.tscn" id="3_cpkwg"]
 [ext_resource type="PackedScene" uid="uid://bwbxe1hh3doh" path="res://src/player/Player.tscn" id="4_smjqx"]
 
 [node name="Game" type="Node3D"]


### PR DESCRIPTION
I really don't know how this happened, but...

The map scene can be accessed correctly on Windows and macOS platforms because their file systems are case-insensitive.

However, trying to run the project on a Linux platform results on error (can't find map.tscn) because the FS is case-sensitive.

Also, the Godot's [PCK's file system is case-sensitive itself](https://docs.godotengine.org/en/4.1/tutorials/best_practices/project_organization.html#case-sensitivity), therefore the error should show up in exported projects no matter the platform.

For now, changing the Map path to match its case is enough.