### PR TITLE
Fix: prevent doubled music

### DIFF
--- a/src/in_game_audio/InGameAudio.cs
+++ b/src/in_game_audio/InGameAudio.cs
@@ -72,11 +72,13 @@ public partial class InGameAudio : Node {
 
   public void StartMainMenuMusic() {
     GameMusic.FadeOut();
+    MainMenuMusic.Stop();
     MainMenuMusic.FadeIn();
   }
 
   public void StartGameMusic() {
     MainMenuMusic.FadeOut();
+    GameMusic.Stop();
     GameMusic.FadeIn();
   }
 }

--- a/test/src/in_game_audio/InGameAudioTest.cs
+++ b/test/src/in_game_audio/InGameAudioTest.cs
@@ -70,6 +70,7 @@ public class InGameAudioTest : TestClass {
   public void PlaysMainMenuMusic() {
     _logic.Setup(logic => logic.Start());
     _gameMusic.Setup(music => music.FadeOut());
+    _mainMenuMusic.Setup(music => music.Stop());
     _mainMenuMusic.Setup(music => music.FadeIn());
 
     _audio.OnResolved();
@@ -84,6 +85,7 @@ public class InGameAudioTest : TestClass {
   [Test]
   public void PlaysGameMusic() {
     _logic.Setup(logic => logic.Start());
+    _gameMusic.Setup(music => music.Stop());
     _gameMusic.Setup(music => music.FadeIn());
     _mainMenuMusic.Setup(music => music.FadeOut());
 


### PR DESCRIPTION
Fixes #5 by stopping and restarting the game music when the player dies.

Additionally, while testing possible fixes for that issue, I discovered that it was also possible to get doubled menu music by starting the game and then rapidly returning to the menu. (Fading the menu music in while it's still fading out kills the tween that eventually stops the old stream.) I've fixed that the same way, by stopping the menu-music player before fading it in when entering the main-menu state.