### PR TITLE
fix: remove architecture layer skipping in InGameUILogic

### DIFF
--- a/src/in_game_ui/InGameUI.cs
+++ b/src/in_game_ui/InGameUI.cs
@@ -45,17 +45,10 @@ public partial class InGameUI : Control, IInGameUI {
 
     InGameUIBinding = InGameUILogic.Bind();
 
-    // TODO: Move the access to the game repo to the state machine.
-
     InGameUIBinding
-      .Handle((in InGameUILogic.Output.NumCoinsCollectedChanged output) =>
+      .Handle((in InGameUILogic.Output.NumCoinsChanged output) =>
         SetCoinsLabel(
-          output.NumCoinsCollected, GameRepo.NumCoinsAtStart.Value
-        )
-      )
-      .Handle((in InGameUILogic.Output.NumCoinsAtStartChanged output) =>
-        SetCoinsLabel(
-          GameRepo.NumCoinsCollected.Value, output.NumCoinsAtStart
+          output.NumCoinsCollected, output.NumCoinsAtStart
         )
       );
 

--- a/src/in_game_ui/state/InGameUILogic.Output.cs
+++ b/src/in_game_ui/state/InGameUILogic.Output.cs
@@ -2,12 +2,8 @@ namespace GameDemo;
 
 public partial class InGameUILogic {
   public static class Output {
-    public readonly record struct NumCoinsCollectedChanged(
-      int NumCoinsCollected
-    );
-
-    public readonly record struct NumCoinsAtStartChanged(
-      int NumCoinsAtStart
+    public readonly record struct NumCoinsChanged(
+      int NumCoinsCollected, int NumCoinsAtStart
     );
   }
 }

--- a/src/in_game_ui/state/InGameUILogic.State.cs
+++ b/src/in_game_ui/state/InGameUILogic.State.cs
@@ -21,9 +21,9 @@ public partial class InGameUILogic {
     }
 
     public void OnNumCoinsCollected(int numCoinsCollected) =>
-      Output(new Output.NumCoinsCollectedChanged(numCoinsCollected));
+      Output(new Output.NumCoinsChanged(numCoinsCollected, Get<IGameRepo>().NumCoinsAtStart.Value));
 
     public void OnNumCoinsAtStart(int numCoinsAtStart) =>
-      Output(new Output.NumCoinsAtStartChanged(numCoinsAtStart));
+      Output(new Output.NumCoinsChanged(Get<IGameRepo>().NumCoinsCollected.Value, numCoinsAtStart));
   }
 }

--- a/test/src/in_game_ui/InGameUITest.cs
+++ b/test/src/in_game_ui/InGameUITest.cs
@@ -70,7 +70,7 @@ public class InGameUITest : TestClass {
     _coinsLabel.SetupSet(label => label.Text = "1/2");
 
     _binding.Output(
-      new InGameUILogic.Output.NumCoinsCollectedChanged(1)
+      new InGameUILogic.Output.NumCoinsChanged(1, 2)
     );
 
     _coinsLabel.VerifyAll();
@@ -86,7 +86,7 @@ public class InGameUITest : TestClass {
     _coinsLabel.SetupSet(label => label.Text = "1/2");
 
     _binding.Output(
-      new InGameUILogic.Output.NumCoinsAtStartChanged(2)
+      new InGameUILogic.Output.NumCoinsChanged(1, 2)
     );
 
     _coinsLabel.VerifyAll();

--- a/test/src/in_game_ui/state/InGameUILogicStateTest.cs
+++ b/test/src/in_game_ui/state/InGameUILogicStateTest.cs
@@ -58,19 +58,27 @@ public class InGameUILogicStateTest : TestClass {
 
   [Test]
   public void OnNumCoinsCollectedOutputs() {
+    var numCoinsAtStart = new AutoProp<int>(10);
+    _gameRepo.Setup(repo => repo.NumCoinsAtStart)
+      .Returns(numCoinsAtStart);
+
     _state.OnNumCoinsCollected(5);
 
     _context.Outputs.ShouldBe(new object[] {
-      new InGameUILogic.Output.NumCoinsCollectedChanged(5)
+      new InGameUILogic.Output.NumCoinsChanged(5, 10)
     });
   }
 
   [Test]
   public void OnNumCoinsAtStartOutputs() {
+    var numCoinsCollected = new AutoProp<int>(5);
+    _gameRepo.Setup(repo => repo.NumCoinsCollected)
+      .Returns(numCoinsCollected);
+
     _state.OnNumCoinsAtStart(10);
 
     _context.Outputs.ShouldBe(new object[] {
-      new InGameUILogic.Output.NumCoinsAtStartChanged(10)
+      new InGameUILogic.Output.NumCoinsChanged(5, 10)
     });
   }
 }


### PR DESCRIPTION
Moved repository access from the visual layer to the state machine for the InGameUI component.