### PR TITLE
fix: use interfaces in models

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
   },
   "sdk": {
     "rollForward": "major",
-    "version": "8.0.303"
+    "version": "7.0.404"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
       "matchPackagePrefixes": [
         "dotnet-sdk"
       ],
-      "allowedVersions": "!/preview/"
+      "allowedVersions": "/^$/"
     },
     {
       "matchPackagePrefixes": [

--- a/src/coin/CoinData.cs
+++ b/src/coin/CoinData.cs
@@ -8,7 +8,7 @@ using Godot;
 [Meta, Id("coin_data")]
 public partial record CoinData {
   [Save("state_machine")]
-  public required CoinLogic StateMachine { get; init; }
+  public required ICoinLogic StateMachine { get; init; }
   [Save("global_transform")]
   public required Transform3D GlobalTransform { get; init; }
 }

--- a/src/map/Map.cs
+++ b/src/map/Map.cs
@@ -64,7 +64,7 @@ public partial class Map : Node3D, IMap {
             elementSelector: coinName => {
               var coin = EntityTable.Get<ICoin>(coinName)!;
               return new CoinData() {
-                StateMachine = (CoinLogic)coin.CoinLogic,
+                StateMachine = coin.CoinLogic,
                 GlobalTransform = coin.GlobalTransform
               };
             }

--- a/src/player/Player.cs
+++ b/src/player/Player.cs
@@ -131,7 +131,7 @@ public partial class Player : CharacterBody3D, IPlayer, IProvide<IPlayerLogic> {
     PlayerChunk = new SaveChunk<PlayerData>(
       onSave: (chunk) => new PlayerData() {
         GlobalTransform = GlobalTransform,
-        StateMachine = (PlayerLogic)PlayerLogic,
+        StateMachine = PlayerLogic,
         Velocity = Velocity
       },
       onLoad: (chunk, data) => {

--- a/src/player/PlayerData.cs
+++ b/src/player/PlayerData.cs
@@ -9,7 +9,7 @@ public partial record PlayerData {
   [Save("global_transform")]
   public required Transform3D GlobalTransform { get; init; }
   [Save("state_machine")]
-  public required PlayerLogic StateMachine { get; init; }
+  public required IPlayerLogic StateMachine { get; init; }
   [Save("velocity")]
   public required Vector3 Velocity { get; init; }
 }

--- a/src/player_camera/PlayerCamera.cs
+++ b/src/player_camera/PlayerCamera.cs
@@ -133,7 +133,7 @@ public partial class PlayerCamera : Node3D, IPlayerCamera {
 
     PlayerCameraChunk = new SaveChunk<PlayerCameraData>(
       onSave: (chunk) => new PlayerCameraData() {
-        StateMachine = (PlayerCameraLogic)CameraLogic,
+        StateMachine = CameraLogic,
         GlobalTransform = GlobalTransform,
         LocalPosition = CameraNode.Position,
         OffsetPosition = OffsetNode.Position,

--- a/src/player_camera/PlayerCameraData.cs
+++ b/src/player_camera/PlayerCameraData.cs
@@ -7,7 +7,7 @@ using Godot;
 [Meta, Id("player_camera_data")]
 public partial record PlayerCameraData {
   [Save("state_machine")]
-  public required PlayerCameraLogic StateMachine { get; init; }
+  public required IPlayerCameraLogic StateMachine { get; init; }
 
   [Save("global_transform")]
   public required Transform3D GlobalTransform { get; init; }

--- a/test/src/player_camera/PlayerCameraTest.cs
+++ b/test/src/player_camera/PlayerCameraTest.cs
@@ -56,6 +56,14 @@ public class PlayerCameraTest : TestClass {
 
     (_playerCam as IAutoInit).IsTesting = true;
 
+    _playerCam.FakeNodeTree(new() {
+      ["%Offset"] = _offsetNode.Object,
+      ["%GimbalHorizontal"] = _gimbalHorizontal.Object,
+      ["%GimbalVertical"] = _gimbalVertical.Object,
+      ["%Camera3D"] = _cameraNode.Object,
+      ["%SpringArmTarget"] = _springArmTarget.Object
+    });
+
     _playerCam.FakeDependency(_gameRepo.Object);
     _playerCam.FakeDependency(_appRepo.Object);
     _playerCam.FakeDependency(_gameChunk.Object);


### PR DESCRIPTION
also prevents renovate from upgrading .NET, since .net8 results in different coverage collection behavior