### PR TITLE
Added [GlobalClass] to PlayerCameraSettings

### DIFF
--- a/src/player_camera/PlayerCamera.tscn
+++ b/src/player_camera/PlayerCamera.tscn
@@ -6,6 +6,7 @@
 [sub_resource type="Resource" id="Resource_qx47m"]
 script = ExtResource("2_xh3xu")
 MouseSensitivity = 0.2
+JoypadSensitivity = 5.0
 VerticalMax = 45.0
 VerticalMin = -45.0
 FollowSpeed = 15.0

--- a/src/player_camera/PlayerCameraSettings.cs
+++ b/src/player_camera/PlayerCameraSettings.cs
@@ -2,6 +2,7 @@ namespace GameDemo;
 
 using Godot;
 
+[GlobalClass]
 public partial class PlayerCameraSettings : Resource {
   [Export(PropertyHint.Range, "0, 10, 0.01")]
   public float MouseSensitivity { get; set; } = 0.2f;


### PR DESCRIPTION
Marked PlayerCameraSettings with [GlobalClass] so it's added to the resource registry and works correctly in inspector.
The camera scene seems to also have been missing JoypadSensitivity in the scene file, just saving the scene with no changes added it, assume this was an issue caused by the class not being in the registry.