### PR TITLE
[chore] create issue templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report something wrong with the project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Describe the bug
+A brief, clear summary of what the bug is.
+
+# Environment
+* **Operating System**: Linux Distribution, MacOS version, or Windows version
+* **.NET SDK version**: Output of `dotnet --list-sdks`
+* **Godot Version**: Click the version number displayed in the lower right corner of Godot's Project Manager or scene tab to copy, then paste here.
+* **IDE**: VS Code, Visual Studio, Rider, ...
+
+# To Reproduce
+Steps to reproduce the behavior. For example:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+# Expected behavior
+A brief, clear description of what you expected to happen.
+
+# Screenshots
+If applicable, add screenshots to help explain your problem.
+
+# Additional context
+Add any other context about the problem here. (For example, any troubleshooting steps you've taken, any relevant environment variables, when the problem started, etc.)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea to improve this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A brief, clear description of what the problem is. For example, "It always takes extra time to configure [...]"
+
+**Describe the solution you'd like**
+A brief, clear description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Created issue templates for community members to report bugs or request features. This should help guide community members on what to include, so issues have all the relevant information for project members to respond effectively.

I tried to make these fairly streamlined while indicating all the information that might be helpful. No suggestion to include an MRP on this project, since people mostly seem to use GameDemo as a reference and would presumably only be reporting bugs that are already present, but I'd probably add it to templates for other projects.