### PR TITLE
chore: disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Chickensoft Discord
+    url: https://discord.gg/gSjaPgMmYW
+    about: Please join us in the Chickensoft Discord server for general questions!


### PR DESCRIPTION
Added an issue-template config file to disable blank issues, encouraging users to use the provided templates. Also added a link to the Chickensoft Discord for general questions.