### PR TITLE
feat: treat CS9057 as error

### DIFF
--- a/GameDemo.csproj
+++ b/GameDemo.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <RootNamespace>GameDemo</RootNamespace>
+    <!-- Catch compiler-mismatch issues with the Introspection generator as early as possible -->
+    <WarningsAsErrors>CS9057</WarningsAsErrors>
     <!-- Required for some nuget packages to work -->
     <!-- godotengine/godot/issues/42271#issuecomment-751423827 -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
The Introspection Generator is compiled against the latest .NET 8 SDK. Because .NET 8 encompasses multiple versions of the .NET compiler, compiling the game project against an older version of .NET 8 may generate a `CS9057` warning to indicate a compiler-version mismatch. However, if the warning is ignored, less-tractable downstream compilation errors may result:

![Screenshot 2025-02-21 100109](https://github.com/user-attachments/assets/9b32d7df-1f15-4d13-bbc6-a6b54124d245)

The warning may even not be reported in some IDE views:

![Screenshot 2025-02-21 100148](https://github.com/user-attachments/assets/b65ef1e2-cfe7-4bfe-8720-f47894ab044c)

We have reports that, in some cases, compilation may succeed and runtime errors may result.

This change therefore updates the GameDemo project, to which we frequently refer users for configuration guidance, to treat `CS9057` as an error. Treating `CS9057` as an error allows users to catch compiler versioning issues at the earliest opportunity:

![Screenshot 2025-02-21 100426](https://github.com/user-attachments/assets/5b900cca-565e-42c8-a87b-bb0327fe5b90)