### PR TITLE
chore: create "build" group in VSCode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,7 @@
       "label": "build",
       "command": "dotnet",
       "type": "process",
+      "group": "build",
       "args": [
         "build",
       ],
@@ -22,6 +23,7 @@
       "label": "build-without-tests",
       "command": "dotnet",
       "type": "process",
+      "group": "build",
       "options": {
         "env": {
           "SKIP_TESTS": "1"


### PR DESCRIPTION
Created a "build" group in the VSCode tasks file, containing both "build" and "build-without-tests", for easy access from VSCode's build action.