### PR TITLE
ci: don't ignore build failures

### DIFF
--- a/.github/workflows/visual_tests.yaml
+++ b/.github/workflows/visual_tests.yaml
@@ -67,7 +67,7 @@ jobs:
           version: global.json
 
       - name: 🧑‍🔬 Generate .NET Bindings
-        run: godot --headless --build-solutions --quit || exit 0
+        run: godot --headless --build-solutions --quit
 
       - name: 🌋 Run Tests in Godot
         run: |


### PR DESCRIPTION
When the visual-tests project build fails, we want to fail the workflow at that point instead of attempting to run the game. (See [this workflow run](https://github.com/chickensoft-games/GameDemo/actions/runs/21363472480/job/61488723292?pr=272) for an example.) Removing the trailing `|| exit 0` from the run command for the build step should accomplish this.