### PR TITLE
chore: update Godot to 4.7 w/GodotNodeInterfaces

### DIFF
--- a/GameDemo.csproj
+++ b/GameDemo.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.6.3">
+<Project Sdk="Godot.NET.Sdk/4.7.0">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
@@ -61,9 +61,9 @@
     <PackageReference Include="Chickensoft.SaveFileBuilder" Version="1.3.73" />
     <PackageReference Include="Chickensoft.AutoInject" Version="2.13.15" PrivateAssets="all" />
     <PackageReference Include="Chickensoft.Collections" Version="3.1.4" />
-    <PackageReference Include="Chickensoft.GodotNodeInterfaces" Version="3.0.20" />
+    <PackageReference Include="Chickensoft.GodotNodeInterfaces" Version="3.0.23" />
     <PackageReference Include="Chickensoft.Introspection" Version="3.0.3" />
-    <PackageReference Include="Chickensoft.Introspection.Generator" Version="3.0.3"  PrivateAssets="all" OutputItemType="analyzer" />
+    <PackageReference Include="Chickensoft.Introspection.Generator" Version="3.0.3" PrivateAssets="all" OutputItemType="analyzer" />
     <PackageReference Include="Chickensoft.Serialization" Version="3.1.0" />
     <PackageReference Include="Chickensoft.Serialization.Godot" Version="0.8.73" />
     <PackageReference Include="Chickensoft.LogicBlocks" Version="6.1.1" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Godot.NET.Sdk": "4.6.3"
+    "Godot.NET.Sdk": "4.7.0"
   },
   "sdk": {
     "rollForward": "major",


### PR DESCRIPTION
* Updated Godot to 4.7.0 in global.json and csproj
* Simultaneously updated GodotNodeInterfaces to latest version to provide compatible interface definitions