### PR TITLE
chore: update Godot.SourceGenerators

### DIFF
--- a/GameDemo.csproj
+++ b/GameDemo.csproj
@@ -57,7 +57,7 @@
     <!-- Production dependencies go here! -->
     <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
     <PackageReference Include="EnvironmentAbstractions" Version="5.0.0" />
-    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.6.0" PrivateAssets="all" OutputItemType="analyzer" />
+    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.7.0" PrivateAssets="all" OutputItemType="analyzer" />
     <PackageReference Include="Chickensoft.SaveFileBuilder" Version="1.3.76" />
     <PackageReference Include="Chickensoft.AutoInject" Version="2.13.21" PrivateAssets="all" />
     <PackageReference Include="Chickensoft.Collections" Version="3.1.4" />

--- a/test/src/app/AppTest.cs
+++ b/test/src/app/AppTest.cs
@@ -79,7 +79,7 @@ public class AppTest : TestClass
 
     _app.Initialize();
 
-    _app.Instantiator.ShouldBeOfType<Instantiator>();
+    _app.Instantiator.ShouldBeOfType<GameDemo.Instantiator>();
     _app.AppRepo.ShouldBeOfType<AppRepo>();
     _app.AppLogic.ShouldBeOfType<AppLogic>();
 

--- a/test/src/utils/InstantiatorTest.cs
+++ b/test/src/utils/InstantiatorTest.cs
@@ -11,7 +11,7 @@ public class InstantiatorTest : TestClass
   [Test]
   public void Instantiates()
   {
-    var instantiator = new Instantiator(TestScene.GetTree());
+    var instantiator = new GameDemo.Instantiator(TestScene.GetTree());
 
     var scene = instantiator.LoadAndInstantiate<Node3D>(
       "res://src/in_game_ui/coin_scene/CoinScene.tscn"


### PR DESCRIPTION
Updated Godot.SourceGenerators to latest. Latest version adds an `Instantiator` type to the `Godot` namespace, conflicting with our own `Instantiator` type. Updated test code using unqualified references to `Instantiator` to reflect that it should be the GameDemo type, not the SourceGenerators type, resolving build errors.